### PR TITLE
Make many enhancements to the rule34.py module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed the `deleted` and `ignore_max_limit` parameters from the `rule34Py.search()` method. Neither worked and only ever returned an exception. (#20)
+- Removed the `limit` parameter from the `rule34Py.icame()` method, as it did nothing. Users are directed to use list slicing instead. (#20)
 
 ### Fixed
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- Added a `rule34Py.iter_search()` method that returns a Post search iterator that transparently handles pagination. (#20)
+- Added a `rule34Py._get()` method to handle HTTP GET requests from the servers. This logic was previously duplicated within most of the client's methods. (#20)
+- Added a `rule34Py.tag_map()` method which parses and returns the top 100 global tags (that was previously being returned from the `tagmap()` method.) (#20)
+- Added a `rule34Py.top_tags()` method, that parses the global Top-100 tags from the toptags page (like the deprecated `tagmap()` method.) (#20)
+- Added a `rule34Py.user_agent` class variable, that users can change to modify the client's User-Agent. (#20)
+
 ### Changed
+
+- Began migrating the client's User-Agent string into a client-scope variable (from the module), so that users can alter it if they wish.
+- `rule34Py` no longer inherits from the `Exception` class.
+
 ### Deprecated
+
+- Announced deprecation of the `rule34Py.rule34Py.version` property. Users should check the value of the module-scope `rule34Py.version` variable instead.  (#20)
+- Announced deprecation of the `rule34Py.rule34Py.tagmap()` method. Users should either call `rule34Py.top_tags()` to continue getting the Top-100 tags chart, or `rule34Py.tag_map()` to get the new Tag Map data points.  (#20)
+
 ### Removed
+
+- Removed the `deleted` and `ignore_max_limit` parameters from the `rule34Py.search()` method. Neither worked and only ever returned an exception. (#20)
+
 ### Fixed
 ### Security
 

--- a/rule34Py/api_urls.py
+++ b/rule34Py/api_urls.py
@@ -4,7 +4,6 @@ rule34Py - Python api wrapper for rule34.xxx
 
 Copyright (C) 2022 Tal A. Baskin <talbaskin.business@gmail.com>
 Copyright (C) 2023-2024 b3yc0d3 <b3yc0d3@gmail.com>
-Copyright (c) 2024 ripariancommit <ripariancommit@protonmail.com>
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/rule34Py/html.py
+++ b/rule34Py/html.py
@@ -6,6 +6,7 @@ import re
 from bs4 import BeautifulSoup
 
 from rule34Py.icame import ICame
+from rule34Py.toptag import TopTag
 
 
 class ICamePage():
@@ -82,3 +83,44 @@ class TagMapPage():
                 map_points[location] = point_data["text"]
 
         return map_points
+
+
+class TopTagsPage():
+    """The rule34.xxx/index.php?Page=toptags page.
+
+    This class can be instantiated as an object that automatically parses
+    the useful information from the page's html, or used as a static class
+    to parse the page's html directly.
+    """
+
+    top_tags: list[TopTag] = []
+
+    def __init__(self, html: str):
+        self.top_tags = TopTagsPage.top_tags_from_html(html)
+        
+    @staticmethod
+    def top_tags_from_html(html: str) -> list[TopTag]:
+        """Parse the "Top 100 tags, global" table from the page.
+        
+        :returns: A list of TopTags representing the top 100 chart.
+        :rtype: list[TopTag]
+        """
+        e_doc = BeautifulSoup(html, features="html.parser")
+        e_rows = e_doc.find("table", class_="server-assigns").find_all("tr")
+
+        top_tags = []
+        # Skip the first two rows; they are the table title and headers.
+        for e_row in e_rows[2:]:
+            e_tags = e_row.find_all("td")
+
+            rank = e_tags[0].string[1:]
+            tagname = e_tags[1].string
+            percentage = e_tags[2].string[:-1]
+
+            top_tags.append(TopTag(
+                rank=rank,
+                tagname=tagname,
+                percentage=percentage,
+            ))
+
+        return top_tags

--- a/rule34Py/html.py
+++ b/rule34Py/html.py
@@ -5,6 +5,44 @@ import re
 
 from bs4 import BeautifulSoup
 
+from rule34Py.icame import ICame
+
+
+class ICamePage():
+    """The Rule34 'icame' page.
+    
+    This class can be instantiated as an object that automatically parses
+    the useful information from the page's html, or used as a static class
+    to parse the page's html directly.
+    """
+
+    top_chart: list[ICame] = []
+
+    def __init__(self, html: str):
+        self.top_chart = ICamePage.top_chart_from_html(html)
+
+    @staticmethod
+    def top_chart_from_html(html: str) -> list[ICame]:
+        """Parse the ICame Top 100 chart from the page html.
+        
+        :returns: A list of the top 100 ICame characters and their counts.
+        :rtype: list[ICame]
+        """
+        e_doc = BeautifulSoup(html, features="html.parser")
+
+        top_chart = []
+        e_rows = e_doc.find("table", border=1).find("tbody").find_all("tr")
+        for e_row in e_rows:
+            if e_row is None:
+                continue
+
+            character_name = e_row.select('td > a', href=True)[0].get_text(strip=True)
+            count = e_row.select('td')[1].get_text(strip=True)
+
+            top_chart.append(ICame(character_name, count))
+
+        return top_chart
+
 
 class TagMapPage():
     """The rule34.xxx/static/tagmap.html page.

--- a/rule34Py/html.py
+++ b/rule34Py/html.py
@@ -1,0 +1,46 @@
+"""This module contains classes for parsing HTML pages from the rule34.xxx site."""
+
+import json
+import re
+
+from bs4 import BeautifulSoup
+
+
+class TagMapPage():
+    """The rule34.xxx/static/tagmap.html page.
+
+    This class can be instantiated as an object that automatically parses
+    the useful information from the page's html, or used as a static class
+    to parse the page's html directly.
+    """
+
+    RE_NEWPLOT = re.compile(r"newPlot\((.*)\)", flags=re.S)
+    RE_PLOT_POINT = re.compile(r"({[^}]+})", flags=re.S)
+    MAP_POINT_KEYS = {"locationmode", "locations", "text"}
+
+    map_points: dict[str, str] = {}
+
+    def __init__(self, html: str):
+        self.map_points = TagMapPage.map_points_from_html(html)
+
+    @staticmethod
+    def map_points_from_html(html: str) -> dict[str, str]:
+        e_doc = BeautifulSoup(html, "html.parser")
+        map_points = {}
+
+        # The map plot script is the 3rd script in the page.
+        e_script_plot = list(e_doc.find_all("script"))[2]
+        match_newplot = TagMapPage.RE_NEWPLOT.search(e_script_plot.text)
+        match_points = TagMapPage.RE_PLOT_POINT.findall(match_newplot.group(1))
+        for match_point in match_points:
+            try:
+                point_data = json.loads(match_point)
+            except json.decoder.JSONDecodeError:
+                # some matches are not tag points and aren't even JSON
+                continue
+            if not TagMapPage.MAP_POINT_KEYS.issubset(point_data.keys()):
+                continue
+            for location in point_data["locations"]:
+                map_points[location] = point_data["text"]
+
+        return map_points

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -57,76 +57,6 @@ class rule34Py():
         """
         pass
 
-    def search(self,
-        tags: list,
-        page_id: int = None,
-        limit: int = 1000,
-        deleted: bool = False,
-        ignore_max_limit: bool = False,
-    ) -> list:
-        """
-        Search for posts.
-
-        :param tags: List of tags.
-        :type tags: list[str]
-
-        :param page_id: Page number/id.
-        :type page_id: int
-
-        :param limit: Limit for posts returned per page (max. 1000).
-        :type limit: int
-
-        :param ignore_max_limit: If limit of 1000 should be ignored.
-        :type ignore_max_limit: bool
-
-        :return: List of Post objects for matching posts.
-        :rtype: list[Post]
-
-        For more information, see:
-
-            - `rule34.xxx API Documentation <https://rule34.xxx/index.php?page=help&topic=dapi>`_
-            - `Tags cheat sheet <https://rule34.xxx/index.php?page=tags&s=list>`_
-        """
-
-        # Check if "limit" is in between 1 and 1000
-        if not ignore_max_limit and limit > 1000 or limit <= 0:
-            raise Exception("invalid value for \"limit\"\n  value must be between 1 and 1000\n  see for more info:\n  https://github.com/b3yc0d3/rule34Py/blob/master/DOC/usage.md#search")
-            return
-
-        params = [
-            ["TAGS", "+".join(tags)],
-            ["LIMIT", str(limit)],
-        ]
-        url = API_URLS.SEARCH.value
-        # Add "page_id"
-        if page_id != None:
-            url += f"&pid={{PAGE_ID}}"
-            params.append(["PAGE_ID", str(page_id)])
-
-        
-        if deleted:
-            raise Exception("To include deleted images is not Implemented yet!")
-            #url += "&deleted=show"
-
-        formatted_url = self._parseUrlParams(url, params)
-        response = requests.get(formatted_url, headers=__headers__)
-        
-        res_status = response.status_code
-        res_len = len(response.content)
-        ret_posts = []
-
-        # checking if status code is not 200
-        # (it's useless currently, becouse rule34.xxx returns always 200 OK regardless of an error)
-        # and checking if content lenths is 0 or smaller
-        # (curetly the only way to check for a error response)
-        if res_status != 200 or res_len <= 0:
-            return ret_posts
-
-        for post in response.json():
-            ret_posts.append(Post.from_json(post))
-
-        return ret_posts
-
     def get_comments(self, post_id: int) -> list:
         """
         Retrieve comments of post by its id.
@@ -300,6 +230,30 @@ class rule34Py():
                 results_count += 1
             page_id += 1
 
+    def _parseUrlParams(self, url: str, params: list) -> str:
+        """
+        Parse url parameters.
+
+        **This function is only used internally.**
+
+        :return: Url filed with filled in placeholders.
+        :rtype: str
+
+        :Example:
+            self._parseUrlParams("domain.com/index.php?v={{VERSION}}", [["VERSION", "1.10"]])
+        """
+
+        # Usage: _parseUrlParams("domain.com/index.php?v={{VERSION}}", [["VERSION", "1.10"]])
+        retURL = url
+
+        for g in params:
+            key = g[0]
+            value = g[1]
+
+            retURL = retURL.replace("{" + key + "}", value)
+
+        return retURL
+
     def random_post(self, tags: list = None):
         """
         Get a random post.
@@ -328,6 +282,91 @@ class rule34Py():
 
         else:
             return self.get_post(self._random_post_id())
+
+    def _random_post_id(self) -> str:
+        """
+        Get a random posts id.
+
+        **This function is only used internally.**
+
+        :return: Random post id
+        :rtype: str
+        """
+
+        res = requests.get(API_URLS.RANDOM_POST.value, headers=__headers__)
+        parsed = urlparse.urlparse(res.url)
+
+        return parse_qs(parsed.query)['id'][0]
+
+    def search(self,
+        tags: list,
+        page_id: int = None,
+        limit: int = 1000,
+        deleted: bool = False,
+        ignore_max_limit: bool = False,
+    ) -> list:
+        """
+        Search for posts.
+
+        :param tags: List of tags.
+        :type tags: list[str]
+
+        :param page_id: Page number/id.
+        :type page_id: int
+
+        :param limit: Limit for posts returned per page (max. 1000).
+        :type limit: int
+
+        :param ignore_max_limit: If limit of 1000 should be ignored.
+        :type ignore_max_limit: bool
+
+        :return: List of Post objects for matching posts.
+        :rtype: list[Post]
+
+        For more information, see:
+
+            - `rule34.xxx API Documentation <https://rule34.xxx/index.php?page=help&topic=dapi>`_
+            - `Tags cheat sheet <https://rule34.xxx/index.php?page=tags&s=list>`_
+        """
+
+        # Check if "limit" is in between 1 and 1000
+        if not ignore_max_limit and limit > 1000 or limit <= 0:
+            raise Exception("invalid value for \"limit\"\n  value must be between 1 and 1000\n  see for more info:\n  https://github.com/b3yc0d3/rule34Py/blob/master/DOC/usage.md#search")
+            return
+
+        params = [
+            ["TAGS", "+".join(tags)],
+            ["LIMIT", str(limit)],
+        ]
+        url = API_URLS.SEARCH.value
+        # Add "page_id"
+        if page_id != None:
+            url += f"&pid={{PAGE_ID}}"
+            params.append(["PAGE_ID", str(page_id)])
+
+        
+        if deleted:
+            raise Exception("To include deleted images is not Implemented yet!")
+            #url += "&deleted=show"
+
+        formatted_url = self._parseUrlParams(url, params)
+        response = requests.get(formatted_url, headers=__headers__)
+        
+        res_status = response.status_code
+        res_len = len(response.content)
+        ret_posts = []
+
+        # checking if status code is not 200
+        # (it's useless currently, becouse rule34.xxx returns always 200 OK regardless of an error)
+        # and checking if content lenths is 0 or smaller
+        # (curetly the only way to check for a error response)
+        if res_status != 200 or res_len <= 0:
+            return ret_posts
+
+        for post in response.json():
+            ret_posts.append(Post.from_json(post))
+
+        return ret_posts
 
     def tagmap(self) -> list:
         """
@@ -370,46 +409,6 @@ class rule34Py():
             #})
 
         return retData
-
-
-    def _random_post_id(self) -> str:
-        """
-        Get a random posts id.
-
-        **This function is only used internally.**
-
-        :return: Random post id
-        :rtype: str
-        """
-
-        res = requests.get(API_URLS.RANDOM_POST.value, headers=__headers__)
-        parsed = urlparse.urlparse(res.url)
-
-        return parse_qs(parsed.query)['id'][0]
-
-    def _parseUrlParams(self, url: str, params: list) -> str:
-        """
-        Parse url parameters.
-
-        **This function is only used internally.**
-
-        :return: Url filed with filled in placeholders.
-        :rtype: str
-
-        :Example:
-            self._parseUrlParams("domain.com/index.php?v={{VERSION}}", [["VERSION", "1.10"]])
-        """
-
-        # Usage: _parseUrlParams("domain.com/index.php?v={{VERSION}}", [["VERSION", "1.10"]])
-        retURL = url
-
-        for g in params:
-            key = g[0]
-            value = g[1]
-
-            retURL = retURL.replace("{" + key + "}", value)
-
-        return retURL
 
     @property
     def version(self) -> str:

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -29,8 +29,7 @@ import requests
 
 from rule34Py.__vars__ import __headers__, __version__, __base_url__
 from rule34Py.api_urls import API_URLS
-from rule34Py.icame import ICame
-from rule34Py.html import TagMapPage
+from rule34Py.html import TagMapPage, ICamePage
 from rule34Py.post import Post
 from rule34Py.post_comment import PostComment
 from rule34Py.toptag import TopTag
@@ -182,39 +181,17 @@ class rule34Py():
         return ret_posts if len(ret_posts) > 1 else (ret_posts[0] if len(ret_posts) == 1 else ret_posts)
 
     def icame(self, limit: int = 100) -> list:
-        """
-        Retrieve list of top 100 iCame list.
+        """Retrieve list of top 100 iCame list.
 
-        :param limit: Limit of returned items.
-                        (Default: ``'100'``)
+        :param limit: Limit of returned items. (Default: ``'100'``)
         :type limit: int
 
         :return: List of iCame objects.
         :rtype: list[ICame]
         """
-
-        response = requests.get(API_URLS.ICAME.value, headers=__headers__)
-
-        res_status = response.status_code
-        res_len = len(response.content)
-        ret_topchart = []
-
-        if res_status != 200 or res_len <= 0:
-            return ret_topchart
-
-        bfs_raw = BeautifulSoup(response.content.decode("utf-8"), features="html.parser")
-        rows = bfs_raw.find("table", border=1).find("tbody").find_all("tr")
-
-        for row in rows:
-            if row == None:
-                continue
-
-            character_name = row.select('td > a', href=True)[0].get_text(strip=True)
-            count = row.select('td')[1].get_text(strip=True)
-
-            ret_topchart.append(ICame(character_name, count))
-
-        return ret_topchart
+        response = self._get(API_URLS.ICAME.value)
+        response.raise_for_status()
+        return ICamePage.top_chart_from_html(response.text)
 
     def iter_search(
         self,

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -2,7 +2,6 @@
 #
 # Copyright (C) 2022 MiningXL <miningxl@gmail.com>
 # Copyright (C) 2022-2024 b3yc0d3 <b3yc0d3@gmail.com>
-# Copyright (c) 2024 ripariancommit <ripariancommit@protonmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -409,10 +409,10 @@ class rule34Py():
 
     @property
     def version(self) -> str:
-        """
-        Rule34Py version.
+        """Rule34Py version.
 
         :return: Version of rule34py.
         :rtype: str
         """
+        raise DeprecationWarning("This method is due to be deprecated in a future release of rule34Py. Use `rule34Py.version` instead.")
         return __version__

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -1,37 +1,36 @@
-""""""
-"""
-rule34Py - Python api wrapper for rule34.xxx
+# rule34Py - Python api wrapper for rule34.xxx
+#
+# Copyright (C) 2022 MiningXL <miningxl@gmail.com>
+# Copyright (C) 2022-2024 b3yc0d3 <b3yc0d3@gmail.com>
+# Copyright (c) 2024 ripariancommit <ripariancommit@protonmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-Copyright (C) 2022 MiningXL <miningxl@gmail.com>
-Copyright (C) 2022-2024 b3yc0d3 <b3yc0d3@gmail.com>
-Copyright (c) 2024 ripariancommit <ripariancommit@protonmail.com>
+"""This module contains the top-level Rule34 API client class."""
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <https://www.gnu.org/licenses/>.
-"""
-
-import requests
+from urllib.parse import parse_qs
 import random
 import urllib.parse as urlparse
+
 from bs4 import BeautifulSoup
-from enum import Enum
-from urllib.parse import parse_qs
-# From this module
-from rule34Py.api_urls import API_URLS, __base_url__
+import requests
+
 from rule34Py.__vars__ import __headers__, __version__
+from rule34Py.api_urls import API_URLS
+from rule34Py.icame import ICame
 from rule34Py.post import Post
 from rule34Py.post_comment import PostComment
-from rule34Py.icame import ICame
 from rule34Py.toptag import TopTag
 
 """

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -38,6 +38,8 @@ from rule34Py.toptag import TopTag
 TODO: fix typos
 """
 
+SEARCH_RESULT_MAX = 1000  # API-defined maximum number of search results per request. <https://rule34.xxx/index.php?page=help&topic=dapi>
+
 
 class rule34Py():
     """The rule34.xxx API client.
@@ -301,8 +303,7 @@ class rule34Py():
     def search(self,
         tags: list,
         page_id: int = None,
-        limit: int = 1000,
-        ignore_max_limit: bool = False,
+        limit: int = SEARCH_RESULT_MAX,
     ) -> list:
         """
         Search for posts.
@@ -316,9 +317,6 @@ class rule34Py():
         :param limit: Limit for posts returned per page (max. 1000).
         :type limit: int
 
-        :param ignore_max_limit: If limit of 1000 should be ignored.
-        :type ignore_max_limit: bool
-
         :return: List of Post objects for matching posts.
         :rtype: list[Post]
 
@@ -329,9 +327,8 @@ class rule34Py():
         """
 
         # Check if "limit" is in between 1 and 1000
-        if not ignore_max_limit and limit > 1000 or limit <= 0:
-            raise Exception("invalid value for \"limit\"\n  value must be between 1 and 1000\n  see for more info:\n  https://github.com/b3yc0d3/rule34Py/blob/master/DOC/usage.md#search")
-            return
+        if limit < 0 or limit > SEARCH_RESULT_MAX:
+            raise ValueError(f"Search limit must be between 0 and {SEARCH_RESULT_MAX}.")
 
         params = [
             ["TAGS", "+".join(tags)],

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -29,7 +29,7 @@ import requests
 
 from rule34Py.__vars__ import __headers__, __version__, __base_url__
 from rule34Py.api_urls import API_URLS
-from rule34Py.html import TagMapPage, ICamePage
+from rule34Py.html import TagMapPage, ICamePage, TopTagsPage
 from rule34Py.post import Post
 from rule34Py.post_comment import PostComment
 from rule34Py.toptag import TopTag
@@ -362,27 +362,9 @@ class rule34Py():
         :return: List of top 100 tags, globally.
         :rtype: list[TopTag]
         """
-        resp = requests.get(API_URLS.TOPMAP.value, headers=__headers__)
-        resp.raise_for_status()
-
-        bfs_raw = BeautifulSoup(resp.content.decode("utf-8"), features="html.parser")
-        rows = bfs_raw.find("table", class_="server-assigns").find_all("tr")
-
-        rows.pop(0)
-        rows.pop(0)
-
-        retData = []
-
-        for row in rows:
-            tags = row.find_all("td")
-
-            rank = tags[0].string[1:]
-            tagname = tags[1].string
-            percentage = tags[2].string[:-1]
-
-            retData.append(TopTag(rank=rank, tagname=tagname, percentage=percentage))
-
-        return retData
+        response = self._get(API_URLS.TOPMAP.value)
+        response.raise_for_status()
+        return TopTagsPage.top_tags_from_html(response.text)
 
     @property
     def version(self) -> str:

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -388,5 +388,8 @@ class rule34Py():
         :return: Version of rule34py.
         :rtype: str
         """
-        raise DeprecationWarning("This method is due to be deprecated in a future release of rule34Py. Use `rule34Py.version` instead.")
+        warnings.warn(
+            "This method is scheduled for deprecation in a future release of rule34Py. Use `rule34Py.version` instead.",
+            DeprecationWarning,
+        )
         return __version__

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -38,17 +38,23 @@ TODO: fix typos
 """
 
 
-# Main Class
-class rule34Py(Exception):
-    """
-    rule34.xxx API wrapper
+class rule34Py():
+    """The rule34.xxx API client.
+
+    Usage:
+    ```python
+    client = rule34Py()
+    post = client.get_post(1234)
+    ```
     """
 
     def __init__(self):
+        """Initialize a new rule34 API client instance.
+
+        :return: A new rule34 API client instance.
+        :rtype: rule34Py
         """
-        rule34.xxx API wrapper
-        """
-        self.__isInit__ = False
+        pass
 
     def search(self,
         tags: list,

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -23,6 +23,7 @@ from collections.abc import Iterator
 from urllib.parse import parse_qs
 import random
 import urllib.parse as urlparse
+import warnings
 
 from bs4 import BeautifulSoup
 import requests
@@ -344,7 +345,7 @@ class rule34Py():
             posts.append(Post.from_json(post_json))
         return posts
 
-    def tagmap(self) -> dict[str, str]:
+    def tag_map(self) -> dict[str, str]:
         """Retrieve the tag map points.
 
         This method uses the tagmap static HTML.
@@ -355,6 +356,20 @@ class rule34Py():
         resp = self._get(__base_url__ + "static/tagmap.html")
         resp.raise_for_status()
         return TagMapPage.map_points_from_html(resp.text)
+
+    def tagmap(self) -> list[TopTag]:
+        """Retrieve list of top 100 global tags.
+
+        This method is deprecated in favor of the top_tags() method.
+
+        :return: List of top 100 tags, globally.
+        :rtype: list[TopTag]
+        """
+        warnings.warn(
+            "The rule34Py.tagmap() method is scheduled for deprecation in a future release. If you want to retrieve the Global Top-100 tags list, use the rule34Py.top_tags() method. If you want to retrieve the tag map data points, use the rule34Py.tag_map() method (with an underscore.)",
+            DeprecationWarning,
+        )
+        return self.top_tags()
 
     def top_tags(self) -> list[TopTag]:
         """Retrieve list of top 100 global tags.

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -51,6 +51,8 @@ class rule34Py():
     ```
     """
 
+    user_agent: str = f"Mozilla/5.0 (compatible; rule34Py/{__version__})"
+
     def __init__(self):
         """Initialize a new rule34 API client instance.
 
@@ -58,6 +60,19 @@ class rule34Py():
         :rtype: rule34Py
         """
         pass
+
+    def _get(self, *args, **kwargs) -> requests.Response:
+        """Send an HTTP GET request.
+
+        This method largely passes its arguments to the requests.get() method,
+        while also inserting a valid User-Agent.
+
+        :return: A requests.Response object from the GET request.
+        :rtype: requests.Response
+        """
+        kwargs["headers"] = kwargs.get("headers", {}) | \
+            {"User-Agent": self.user_agent}
+        return requests.get(*args, **kwargs)
 
     def get_comments(self, post_id: int) -> list:
         """

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -302,7 +302,6 @@ class rule34Py():
         tags: list,
         page_id: int = None,
         limit: int = 1000,
-        deleted: bool = False,
         ignore_max_limit: bool = False,
     ) -> list:
         """
@@ -343,11 +342,6 @@ class rule34Py():
         if page_id != None:
             url += f"&pid={{PAGE_ID}}"
             params.append(["PAGE_ID", str(page_id)])
-
-        
-        if deleted:
-            raise Exception("To include deleted images is not Implemented yet!")
-            #url += "&deleted=show"
 
         formatted_url = self._parseUrlParams(url, params)
         response = requests.get(formatted_url, headers=__headers__)

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -180,11 +180,8 @@ class rule34Py():
 
         return ret_posts if len(ret_posts) > 1 else (ret_posts[0] if len(ret_posts) == 1 else ret_posts)
 
-    def icame(self, limit: int = 100) -> list:
+    def icame(self) -> list:
         """Retrieve list of top 100 iCame list.
-
-        :param limit: Limit of returned items. (Default: ``'100'``)
-        :type limit: int
 
         :return: List of iCame objects.
         :rtype: list[ICame]

--- a/tests/unit/test_html.py
+++ b/tests/unit/test_html.py
@@ -1,13 +1,22 @@
 
 import pytest
 
-from rule34Py.html import TagMapPage, ICamePage
-from rule34Py.icame import ICame
 from rule34Py.api_urls import API_URLS
+from rule34Py.html import TagMapPage, ICamePage, TopTagsPage
+from rule34Py.icame import ICame
+from rule34Py.toptag import TopTag
 
 
 ICAME_CHART_LEN = 100  # It's the top-100 chart.
 TAGMAP_LOCATION_COUNT = 285  # There are 285 districts on the map
+TOP_TAGS_CHART_LEN = 100  # It's a top-100 chart.
+
+
+@pytest.fixture(scope="module")
+def icame_html(rule34):
+    resp = rule34._get(API_URLS.ICAME.value)
+    resp.raise_for_status()
+    return resp.text
 
 
 @pytest.fixture(scope="module")
@@ -16,10 +25,9 @@ def tagmap_html(rule34):
     resp.raise_for_status()
     return resp.text
 
-
 @pytest.fixture(scope="module")
-def icame_html(rule34):
-    resp = rule34._get(API_URLS.ICAME.value)
+def toptags_html(rule34):
+    resp = rule34._get(API_URLS.TOPMAP.value)
     resp.raise_for_status()
     return resp.text
 
@@ -51,3 +59,17 @@ def test_TagMapPage_map_points_from_html(tagmap_html):
     pprint(map_points)
     assert isinstance(map_points, dict)
     assert len(map_points.keys()) == TAGMAP_LOCATION_COUNT
+
+
+def test_TopTagsPage(toptags_html):
+    """The TopTagsPage class can be instantiated from html."""
+    page = TopTagsPage(toptags_html)
+    assert len(page.top_tags) == TOP_TAGS_CHART_LEN
+
+
+def test_TopTagsPage_top_tags_from_html(toptags_html):
+    """TopTagsPage.top_tags_from_html() parses the icame chart from html."""
+    top_tags = TopTagsPage.top_tags_from_html(toptags_html)
+    assert isinstance(top_tags, list)
+    assert len(top_tags) == TOP_TAGS_CHART_LEN
+    assert isinstance(top_tags[0], TopTag)

--- a/tests/unit/test_html.py
+++ b/tests/unit/test_html.py
@@ -1,9 +1,12 @@
 
 import pytest
 
-from rule34Py.html import TagMapPage
+from rule34Py.html import TagMapPage, ICamePage
+from rule34Py.icame import ICame
+from rule34Py.api_urls import API_URLS
 
 
+ICAME_CHART_LEN = 100  # It's the top-100 chart.
 TAGMAP_LOCATION_COUNT = 285  # There are 285 districts on the map
 
 
@@ -12,6 +15,27 @@ def tagmap_html(rule34):
     resp = rule34._get("https://rule34.xxx/static/tagmap.html")
     resp.raise_for_status()
     return resp.text
+
+
+@pytest.fixture(scope="module")
+def icame_html(rule34):
+    resp = rule34._get(API_URLS.ICAME.value)
+    resp.raise_for_status()
+    return resp.text
+
+
+def test_ICamePage_init(icame_html):
+    """The ICamePage class can be instantiated from html."""
+    icame_page = ICamePage(icame_html)
+    assert len(icame_page.top_chart) == ICAME_CHART_LEN
+
+
+def test_ICamePage_top_chart_from_html(icame_html):
+    """ICamePage.top_chart_from_html() parses the icame chart from html."""
+    top_chart = ICamePage.top_chart_from_html(icame_html)
+    assert isinstance(top_chart, list)
+    assert len(top_chart) == ICAME_CHART_LEN
+    assert isinstance(top_chart[0], ICame)
 
 
 def test_TagMapPage_init(tagmap_html):

--- a/tests/unit/test_html.py
+++ b/tests/unit/test_html.py
@@ -1,0 +1,29 @@
+
+import pytest
+
+from rule34Py.html import TagMapPage
+
+
+TAGMAP_LOCATION_COUNT = 285  # There are 285 districts on the map
+
+
+@pytest.fixture(scope="module")
+def tagmap_html(rule34):
+    resp = rule34._get("https://rule34.xxx/static/tagmap.html")
+    resp.raise_for_status()
+    return resp.text
+
+
+def test_TagMapPage_init(tagmap_html):
+    """The TagMapPage class can be instantiated on its own."""
+    tagmap = TagMapPage(tagmap_html)
+    assert len(tagmap.map_points.keys()) == TAGMAP_LOCATION_COUNT
+
+
+def test_TagMapPage_map_points_from_html(tagmap_html):
+    """TagMapPage.map_points_from_html() parses tagmap data from html."""
+    map_points = TagMapPage.map_points_from_html(tagmap_html)
+    from pprint import pprint
+    pprint(map_points)
+    assert isinstance(map_points, dict)
+    assert len(map_points.keys()) == TAGMAP_LOCATION_COUNT

--- a/tests/unit/test_module.py
+++ b/tests/unit/test_module.py
@@ -1,0 +1,11 @@
+"""This module contains unit tests for the rule34Py top-level module."""
+
+import re
+
+import rule34Py
+
+
+def test_version():
+    """The module should contain a version triplet in a `version` variable."""
+    RE_VERSION = re.compile(r"^\d+\.\d+\.\d+$")
+    assert RE_VERSION.match(rule34Py.version)

--- a/tests/unit/test_rule34Py.py
+++ b/tests/unit/test_rule34Py.py
@@ -59,6 +59,31 @@ def test_rule34Py_icame(rule34):
     # TODO: test the `limit` parameter once, it is working.
 
 
+def test_rule34Py_iter_search(rule34):
+    """The iter_search() method will iterate over post search results.
+    """
+    # The method returns an iterator.
+    from collections.abc import Iterator
+    iter = rule34.iter_search()
+    assert isinstance(iter, Iterator)
+    # You can loop over that iterator and get Post objects.
+    for post in rule34.iter_search():
+        assert isinstance(post, Post)
+        break
+    # By default, it will iterate until the end of the search results.
+    # The "1938" tag is a pretty safe bet to have very few results.
+    results = list(rule34.iter_search(tags=["1938"]))
+    assert len(results) > 0
+    # But you can also specify a max_number of results.
+    # The "female" tag is basically guaranteed to have a bunch of results.
+    results = list(rule34.iter_search(["female"], max_results=17))
+    assert len(results) == 17
+    # If the max_results are greater than a single page, the iterator will
+    # transparently move to the next page.
+    results = list(rule34.iter_search(["female"], max_results=1002))
+    assert len(results) == 1002
+
+
 def test_rule34Py_random_post(rule34):
     """The client random_post() method fetches a random Post object.
     """

--- a/tests/unit/test_rule34Py.py
+++ b/tests/unit/test_rule34Py.py
@@ -4,6 +4,7 @@ import pytest
 
 from rule34Py import Post
 from rule34Py.post_comment import PostComment
+from rule34Py.icame import ICame
 
 
 def test_rule34Py_get_comments(rule34):
@@ -45,6 +46,16 @@ def test_rule34Py_get_post(rule34):
     post = rule34.get_post(TEST_POST_ID)
     assert isinstance(post, Post)
     assert post.id == TEST_POST_ID
+
+
+def test_rule34Py_icame(rule34):
+    """The client icame() method fetches the icame leaderboard as a list.
+    """
+    icame = rule34.icame()
+    assert isinstance(icame, list)
+    assert len(icame) == 100  # the list length is 100 by default
+    assert isinstance(icame[0], ICame)
+    # TODO: test the `limit` parameter once, it is working.
 
 
 def test_rule34Py_search(rule34):

--- a/tests/unit/test_rule34Py.py
+++ b/tests/unit/test_rule34Py.py
@@ -128,9 +128,20 @@ def test_rule34Py_search(rule34):
 
 
 def test_rule34Py_tagmap(rule34):
-    """The client tagmap() method should return the 100 TopTags.
+    """The client tagmap() method should return a map of tags.
     """
     tagmap = rule34.tagmap()
-    assert isinstance(tagmap, list)
-    assert len(tagmap) == 100
-    assert isinstance(tagmap[0], TopTag)
+    assert isinstance(tagmap, dict)
+    assert len(tagmap) > 0
+    for key, value in tagmap.items():
+        assert isinstance(key, str)
+        assert isinstance(value, str)
+        break  # just check the first tagmap point
+
+def test_rule34Py_top_tags(rule34):
+    """The top_tags() method returns a list of the top 100 global tags.
+    """
+    top_tags = rule34.top_tags()
+    assert isinstance(top_tags, list)
+    assert len(top_tags) == 100
+    assert isinstance(top_tags[0], TopTag)

--- a/tests/unit/test_rule34Py.py
+++ b/tests/unit/test_rule34Py.py
@@ -38,6 +38,15 @@ def test_rule34Py_get_pool(rule34):
     assert posts[0].id == FIRST_POST_ID
 
 
+def test_rule34Py_get_post(rule34):
+    """The client get_post() method fetches a single Post.
+    """
+    TEST_POST_ID = 3471384
+    post = rule34.get_post(TEST_POST_ID)
+    assert isinstance(post, Post)
+    assert post.id == TEST_POST_ID
+
+
 def test_rule34Py_search(rule34):
     """The client can search for posts by tags, with pagination."""
     # search by single tag

--- a/tests/unit/test_rule34Py.py
+++ b/tests/unit/test_rule34Py.py
@@ -1,5 +1,7 @@
 """These tests confirm the functionality of the rule34Py.rule34 class.
 """
+import re
+
 import pytest
 
 from rule34Py import Post
@@ -141,8 +143,11 @@ def test_rule34Py_tag_map(rule34):
 
 def test_rule34Py_tagmap(rule34):
     """The old tagmap() method should throw a deprecation warning, but return the top_tags() method."""
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning) as warnings:
         top_tags = rule34.tagmap()
+    # The warning message should direct the user to the new methods.
+    assert re.match(r".*top_tags.*", str(warnings[0].message))
+    assert re.match(r".*tag_map.*", str(warnings[0].message))
     assert isinstance(top_tags, list)
     assert isinstance(top_tags[0], TopTag)
 
@@ -156,10 +161,14 @@ def test_rule34Py_top_tags(rule34):
     assert isinstance(top_tags[0], TopTag)
 
 def test_rule34Py_version(rule34):
-    """The version() property should just raise a deprecation warning.
+    """The version() property should throw a deprecation warning, but return its original value.
     
     Remove this test when the method is removed.
     """
-    with pytest.raises(DeprecationWarning) as ex:
-        rule34.version
-    assert ex.match(r".*Use `rule34Py.version` instead.*")
+    with pytest.warns(
+        DeprecationWarning,
+        match=r".*Use `rule34Py.version` instead.*",
+    ):
+        version = rule34.version
+    assert re.match(r"^\d+\.\d+\.\d+$", version)
+

--- a/tests/unit/test_rule34Py.py
+++ b/tests/unit/test_rule34Py.py
@@ -127,16 +127,25 @@ def test_rule34Py_search(rule34):
         rule34.search([], limit=SEARCH_RESULT_MAX + 1)
 
 
-def test_rule34Py_tagmap(rule34):
-    """The client tagmap() method should return a map of tags.
+def test_rule34Py_tag_map(rule34):
+    """The client tag_map() method should return a map of tags.
     """
-    tagmap = rule34.tagmap()
-    assert isinstance(tagmap, dict)
-    assert len(tagmap) > 0
-    for key, value in tagmap.items():
+    tag_map = rule34.tag_map()
+    assert isinstance(tag_map, dict)
+    assert len(tag_map) > 0
+    for key, value in tag_map.items():
         assert isinstance(key, str)
         assert isinstance(value, str)
-        break  # just check the first tagmap point
+        break  # just check the first tag_map point
+
+
+def test_rule34Py_tagmap(rule34):
+    """The old tagmap() method should throw a deprecation warning, but return the top_tags() method."""
+    with pytest.warns(DeprecationWarning):
+        top_tags = rule34.tagmap()
+    assert isinstance(top_tags, list)
+    assert isinstance(top_tags[0], TopTag)
+
 
 def test_rule34Py_top_tags(rule34):
     """The top_tags() method returns a list of the top 100 global tags.

--- a/tests/unit/test_rule34Py.py
+++ b/tests/unit/test_rule34Py.py
@@ -3,6 +3,18 @@
 import pytest
 
 from rule34Py import Post
+from rule34Py.post_comment import PostComment
+
+
+def test_rule34Py_get_comments(rule34):
+    """The get_comments() method should fetch a list of comments from a post.
+    """
+    # TEST_POST_ID is the oldest post from search `neko rating:safe` with multiple comments.
+    TEST_POST_ID = 3471384
+    comments = rule34.get_comments(TEST_POST_ID)
+    assert isinstance(comments, list)
+    assert len(comments) > 1
+    assert isinstance(comments[0], PostComment)
 
 
 def test_rule34Py_get_pool(rule34):
@@ -50,3 +62,14 @@ def test_rule34Py_search(rule34):
     assert len(results3) == 20
     print(set(ids3) - set(ids1))
     assert set(ids3).issubset(set(ids1))
+
+
+def test_rule34Py_get_comments(rule34):
+    """The get_comments() method should fetch a list of comments from a post.
+    """
+    # TEST_POST_ID is the oldest post from search `neko rating:safe` with multiple comments.
+    TEST_POST_ID = 3471384
+    comments = rule34.get_comments(TEST_POST_ID)
+    assert isinstance(comments, list)
+    assert len(comments) > 1
+    assert isinstance(comments[0], PostComment)

--- a/tests/unit/test_rule34Py.py
+++ b/tests/unit/test_rule34Py.py
@@ -5,6 +5,7 @@ import pytest
 from rule34Py import Post
 from rule34Py.post_comment import PostComment
 from rule34Py.icame import ICame
+from rule34Py.toptag import TopTag
 
 
 def test_rule34Py_get_comments(rule34):
@@ -58,6 +59,16 @@ def test_rule34Py_icame(rule34):
     # TODO: test the `limit` parameter once, it is working.
 
 
+def test_rule34Py_random_post(rule34):
+    """The client random_post() method fetches a random Post object.
+    """
+    post = rule34.random_post()
+    assert isinstance(post, Post)
+    # You can specify tags to limit the random search
+    post = rule34.random_post(tags=["neko"])
+    assert "neko" in post.tags
+
+
 def test_rule34Py_search(rule34):
     """The client can search for posts by tags, with pagination."""
     # search by single tag
@@ -84,12 +95,10 @@ def test_rule34Py_search(rule34):
     assert set(ids3).issubset(set(ids1))
 
 
-def test_rule34Py_get_comments(rule34):
-    """The get_comments() method should fetch a list of comments from a post.
+def test_rule34Py_tagmap(rule34):
+    """The client tagmap() method should return the 100 TopTags.
     """
-    # TEST_POST_ID is the oldest post from search `neko rating:safe` with multiple comments.
-    TEST_POST_ID = 3471384
-    comments = rule34.get_comments(TEST_POST_ID)
-    assert isinstance(comments, list)
-    assert len(comments) > 1
-    assert isinstance(comments[0], PostComment)
+    tagmap = rule34.tagmap()
+    assert isinstance(tagmap, list)
+    assert len(tagmap) == 100
+    assert isinstance(tagmap[0], TopTag)

--- a/tests/unit/test_rule34Py.py
+++ b/tests/unit/test_rule34Py.py
@@ -3,6 +3,7 @@
 import pytest
 
 from rule34Py import Post
+from rule34Py.rule34 import SEARCH_RESULT_MAX
 from rule34Py.post_comment import PostComment
 from rule34Py.icame import ICame
 from rule34Py.toptag import TopTag
@@ -102,7 +103,7 @@ def test_rule34Py_search(rule34):
     print(f"ids1={ids1[:10]}...")
     assert isinstance(results1, list)  # return type is list
     
-    assert len(results1) == 1000  # should return the maximum number of posts (1000)
+    assert len(results1) == SEARCH_RESULT_MAX
     assert isinstance(results1[0], Post)  # return list contains Post objects
 
     # get a second page of results
@@ -118,6 +119,12 @@ def test_rule34Py_search(rule34):
     assert len(results3) == 20
     print(set(ids3) - set(ids1))
     assert set(ids3).issubset(set(ids1))
+
+    # Invalid arguments - limit
+    with pytest.raises(ValueError) as e:
+        rule34.search([], limit=-10)
+    with pytest.raises(ValueError):
+        rule34.search([], limit=SEARCH_RESULT_MAX + 1)
 
 
 def test_rule34Py_tagmap(rule34):

--- a/tests/unit/test_rule34Py.py
+++ b/tests/unit/test_rule34Py.py
@@ -145,3 +145,12 @@ def test_rule34Py_top_tags(rule34):
     assert isinstance(top_tags, list)
     assert len(top_tags) == 100
     assert isinstance(top_tags[0], TopTag)
+
+def test_rule34Py_version(rule34):
+    """The version() property should just raise a deprecation warning.
+    
+    Remove this test when the method is removed.
+    """
+    with pytest.raises(DeprecationWarning) as ex:
+        rule34.version
+    assert ex.match(r".*Use `rule34Py.version` instead.*")

--- a/tests/unit/test_rule34Py.py
+++ b/tests/unit/test_rule34Py.py
@@ -59,7 +59,6 @@ def test_rule34Py_icame(rule34):
     assert isinstance(icame, list)
     assert len(icame) == 100  # the list length is 100 by default
     assert isinstance(icame[0], ICame)
-    # TODO: test the `limit` parameter once, it is working.
 
 
 def test_rule34Py_iter_search(rule34):


### PR DESCRIPTION
This patchset makes many changes (below) to the `rule34.py` file and its `rule34Py` client class. Some changes are marked as breaking backwards compatibility. In other cases, I have installed a DeprecationWarning to let users know that they will be removed in the future. All changes introduced by this patchset, as well as `rule34Py` original behavior that I touched, have unit tests associated with them.

This PR is probably about half of the client class changes I'm ever going to make. But I wanted to post it because it is already very long and I'd like feedback on my general approaches before I get too deep. Also, I may not have the opportunity to do more work on this project during the weekdays; so my next PR may not be until next weekend.

# Changes

### Added

- Added new tests for rule34Py:
	* get_comments()
	* get_post()
	* icame()
	* iter_search()
	* tag_map()
	* tagmap()
	* top_tags()
	* version()
- Added test cases for all the new `html` module classes and static methods.
- Added a `rule34Py.iter_search()` method that returns a Post search iterator that transparently handles pagination.
- Added a `rule34Py._get()` method to handle HTTP GET requests from the servers. This logic was previously duplicated within most of the client's methods.
- Added a `rule34Py.tag_map()` method which parses and returns the top 100 global tags (that was previously being returned from the `tagmap()` method.)
- Added a `rule34Py.top_tags()` method, that parses the global Top-100 tags from the toptags page (like the deprecated `tagmap()` method.)

### Changed

- Began migrating the client's User-Agent string into a client-scope variable (from the module), so that users can alter it if they wish.
- Cleaned up the module docstrings, copyright header, and imports in rule34.py.
- Alpha-sorted the `rule34.py` file.
- **(Breaking)** `rule34Py` no longer inherits from the `Exception` class.
- Generally began migrating the HTML parsing logic out of the rule34Py client class and into a new `html` module.

### Deprecated

- Announced deprecation of the `rule34Py.rule34Py.version` property. Users should check the value of the module-scope `rule34Py.version` variable instead.
- Announced deprecation of the `rule34Py.rule34Py.tagmap()` method. Users should either call `rule34Py.top_tags()` to continue getting the Top-100 tags chart, or `rule34Py.tag_map()` to get the new Tag Map data points.

### Removed

- **(Breaking)** Removed the `deleted` and `ignore_max_limit` parameters from the `rule34Py.search()` method. Neither worked and only ever returned an exception.
- Removed the `limit` parameter from the `rule34Py.icame()` method, as it did nothing. Users are directed to use list slicing instead.


# Testing

Autotest run with this patchset.
```
$ make check
./.venv/bin/python3 -m pytest tests/
==== test session starts ===
platform linux -- Python 3.12.5, pytest-8.3.2, pluggy-1.5.0 -- rule34Py/.venv/bin/python3
cachedir: .pytest_cache
rootdir: rule34Py/tests
configfile: pytest.ini
collected 25 items                                                                                                                                            

tests/unit/test_html.py::test_ICamePage_init PASSED                                                                                                     [  4%]
tests/unit/test_html.py::test_ICamePage_top_chart_from_html PASSED                                                                                      [  8%]
tests/unit/test_html.py::test_TagMapPage_init PASSED                                                                                                    [ 12%]
tests/unit/test_html.py::test_TagMapPage_map_points_from_html PASSED                                                                                    [ 16%]
tests/unit/test_html.py::test_TopTagsPage PASSED                                                                                                        [ 20%]
tests/unit/test_html.py::test_TopTagsPage_top_tags_from_html PASSED                                                                                     [ 24%]
tests/unit/test_module.py::test_version PASSED                                                                                                          [ 28%]
tests/unit/test_readme.py::test_module_import PASSED                                                                                                    [ 32%]
tests/unit/test_readme.py::test_get_comments PASSED                                                                                                     [ 36%]
tests/unit/test_readme.py::test_get_post PASSED                                                                                                         [ 40%]
tests/unit/test_readme.py::test_icame PASSED                                                                                                            [ 44%]
tests/unit/test_readme.py::test_search PASSED                                                                                                           [ 48%]
tests/unit/test_readme.py::test_get_pool PASSED                                                                                                         [ 52%]
tests/unit/test_readme.py::test_random_post PASSED                                                                                                      [ 56%]
tests/unit/test_rule34Py.py::test_rule34Py_get_comments PASSED                                                                                          [ 60%]
tests/unit/test_rule34Py.py::test_rule34Py_get_pool PASSED                                                                                              [ 64%]
tests/unit/test_rule34Py.py::test_rule34Py_get_post PASSED                                                                                              [ 68%]
tests/unit/test_rule34Py.py::test_rule34Py_icame PASSED                                                                                                 [ 72%]
tests/unit/test_rule34Py.py::test_rule34Py_iter_search PASSED                                                                                           [ 76%]
tests/unit/test_rule34Py.py::test_rule34Py_random_post PASSED                                                                                           [ 80%]
tests/unit/test_rule34Py.py::test_rule34Py_search PASSED                                                                                                [ 84%]
tests/unit/test_rule34Py.py::test_rule34Py_tag_map PASSED                                                                                               [ 88%]
tests/unit/test_rule34Py.py::test_rule34Py_tagmap PASSED                                                                                                [ 92%]
tests/unit/test_rule34Py.py::test_rule34Py_top_tags PASSED                                                                                              [ 96%]
tests/unit/test_rule34Py.py::test_rule34Py_version PASSED                                                                                               [100%]

==== 25 passed in 6.93s ===
```

The new `rule34Py.version` DeprecationWarning.
```
$ PYTHONPATH=. python3 -X dev -c "import rule34Py; print(rule34Py.rule34Py().version)"
.../rule34Py/rule34.py:390: DeprecationWarning: This method is scheduled for deprecation in a future release of rule34Py. Use `rule34Py.version` instead.
  warnings.warn(
2.0.0
```

The new `rule34Py.tagmap()` DeprecationWarning.
```
$ PYTHONPATH=. python3 -X dev -c "import rule34Py; print(rule34Py.rule34Py().tagmap())"
/mnt/enc2/kasper/src/rule34Py/rule34Py/rule34.py:367: DeprecationWarning: The rule34Py.tagmap() method is scheduled for deprecation in a future release. If you want to retrieve the Global Top-100 tags list, use the rule34Py.top_tags() method. If you want to retrieve the tag map data points, use the rule34Py.tag_map() method (with an underscore.)
  warnings.warn(
[<rule34Py.toptag.TopTag object at 0x7f9250f39050>, ...
```

Example `rule34Py.tag_map()` output.
```
$ PYTHONPATH=. python3 -c 'import rule34Py; print(rule34Py.rule34Py().tag_map())'
{'AUS': 'futanari', 'SGP': 'futanari', 'TWN': 'sakimichan', 'THA': 'sakimichan', 'MUS': 'straight', ...}
```

# Procedure
* I release all my copyright for this PR to @b3yc0d3.
* This PR includes changes that break backwards API compatibility.
* This PR updates the CHANGELOG.