### PR TITLE
Revitalize the client module (part 2 / 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added captcha-compliance capabilities. You can now pass the client your captcha clearance token by completing the captcha in your browser, opening the response header, and writing your `cf_clearance` token into the client's `rule34Py.captcha_clearance` attribute and setting the client's `user_agent` attribute to match your browser.
+	- Alternatively, set your execution environment's `R34_CAPTCHA_CLEARANCE` and `R34_USER_AGENT` variables to the appropriate values. The client will read form them during initialization.
+- Added a rate limiter for requests to the rule34.xxx base site (the PHP endpoint). By default, the client will now limit API calls that use this endpoint to 1 per second.
+	- This behavior can be disabled by setting `rule34Py.set_base_site_rate_limit(False)`.
+	- There is no rate limit on the api.rule34.xxx endpoint, which is assumed to handle rate-limiting on the server-side.
+	- This new feature requires the `requests-ratelimiter` module.
+
+### Changed
+
+- Changed the behavior of the `rule34Py.random_post()` method to function more like the website. The method now accepts no `tag` parameters, and returns a random post ID from all posts on the site. Users who want to use the old behavior of returning a random post from the first 1000 tag-search results are directed to do something like `random.choice(rule34Py.search([tags...]))`.
+- Changed the `rule34Py.get_pool()` method to return a `Pool` object containing more complete information about a Pool.
+	- The Pool's post ids can be accessed via the `Pool.posts` attribute.
+
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+
+
+## [2.1.0] - 2024-12-31
+
+### Added
+
 - Added a `rule34Py.iter_search()` method that returns a Post search iterator that transparently handles pagination. (#20)
 - Added a `rule34Py._get()` method to handle HTTP GET requests from the servers. This logic was previously duplicated within most of the client's methods. (#20)
 - Added a `rule34Py.tag_map()` method which parses and returns the top 100 global tags (that was previously being returned from the `tagmap()` method.) (#20)
@@ -31,8 +55,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the `deleted` and `ignore_max_limit` parameters from the `rule34Py.search()` method. Neither worked and only ever returned an exception. (#20)
 - Removed the `limit` parameter from the `rule34Py.icame()` method, as it did nothing. Users are directed to use list slicing instead. (#20)
 
-### Fixed
-### Security
 
 
 ## [2.0.0] - 2024-09-02

--- a/README.md
+++ b/README.md
@@ -32,23 +32,26 @@ You can find the documentation [here](https://github.com/b3yc0d3/rule34Py/tree/m
 from rule34Py import rule34Py
 r34Py = rule34Py()
 
-# get comments of an post
+# Get comments of an post.
 r34Py.get_comments(4153825)
 
-# get post by its id
+# Get post by its id.
 r34Py.get_post(4153825)
 
-# get top 100 icame
+# Get top 100 icame.
 r34Py.icame()
 
-# search for posts by tag(s)
+# Search for posts by tag(s).
 r34Py.search(["neko"], page_id=2, limit=50)
 
-# get pool by id
+# Get pool by id.
 r34Py.get_pool(28)
 
-# get a random post (in this case with tag(s))
-random = r34Py.random_post(["neko"])
+# Get a random post.
+random = r34Py.random_post()
+
+# Get just a random post ID.
+random_id = r34Py.random_post_id()
 ```
 
 ## Development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rule34Py"
-description = "API wraper for rule34.xxx"
+description = "API wrapper for rule34.xxx"
 version = "2.1.0"
 license = {file = "LICENSE"}
 readme = "README.md"
@@ -16,6 +16,7 @@ maintainers = [
 	{ name = "b3yc0d3", email = "b3yc0d3@gmail.com" }
 ]
 dependencies = [
+	"requests-ratelimiter >= 0.7.0",
     "beautifulsoup4 >= 4.9.3",
     "requests >= 2.27.1",
     "lxml >= 4.6.4"
@@ -44,3 +45,9 @@ Documentation = "https://github.com/b3yc0d3/rule34Py/tree/master/docs"
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[project.optional-dependencies]
+test = [
+	"pytest >= 8.3.2",
+	"responses >= 0.25.3",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ license = {file = "LICENSE"}
 readme = "README.md"
 keywords = [ "rule34.xxx", "adult", "nsfw", "rule34-pi", "api-client" ]
 authors = [
-    { name = "MiningXL", email = "miningxl@gmail.com" },
+	{ name = "MiningXL", email = "miningxl@gmail.com" },
 	{ name = "b3yc0d3", email = "b3yc0d3@gmail.com" },
 	{ name = "Tal A. Baskin", email = "talbaskin.business@gmail.com" },
 	{ name = "ripariancommit", email = "ripariancommit@protonmail.com" }
@@ -17,9 +17,9 @@ maintainers = [
 ]
 dependencies = [
 	"requests-ratelimiter >= 0.7.0",
-    "beautifulsoup4 >= 4.9.3",
-    "requests >= 2.27.1",
-    "lxml >= 4.6.4"
+	"beautifulsoup4 >= 4.9.3",
+	"lxml >= 4.6.4",
+	"requests >= 2.27.1",
 ]
 classifiers = [
 	"Development Status :: 4 - Beta",

--- a/rule34Py/__init__.py
+++ b/rule34Py/__init__.py
@@ -22,5 +22,6 @@ from rule34Py.rule34 import rule34Py
 from rule34Py.icame import ICame
 from rule34Py.post import Post
 from rule34Py.toptag import TopTag
+from rule34Py.pool import Pool, PoolHistoryEvent
 
 from rule34Py.__vars__ import __version__ as version

--- a/rule34Py/__vars__.py
+++ b/rule34Py/__vars__.py
@@ -28,8 +28,3 @@ __version__ = ".".join(__version__tuple__) # xx.xx.xx
 # Variables
 __base_url__ = "https://rule34.xxx/"
 __api_url__ = "https://api.rule34.xxx/"
-__useragent__ = f"Mozilla/5.0 (compatible; rule34Py/{__version__})"
-
-__headers__ = {
-    "User-Agent": __useragent__
-}

--- a/rule34Py/pool.py
+++ b/rule34Py/pool.py
@@ -1,0 +1,25 @@
+"""This module provides classes representing the Rule34 website's Pool objects."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass
+class PoolHistoryEvent():
+    """A Rule34 Pool history record."""
+
+    date: datetime
+    updater_uname: str
+    post_ids: list[int] = field(default_factory=list())
+
+
+@dataclass
+class Pool():
+    """A collection of Rule34 Posts."""
+
+    pool_id: int
+    name: str
+    description: str
+
+    posts: list[int] = field(default_factory = list)
+

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -20,7 +20,7 @@
 
 from collections.abc import Iterator
 from urllib.parse import parse_qs
-import random
+import os
 import urllib.parse as urlparse
 import warnings
 
@@ -51,7 +51,10 @@ class rule34Py():
     ```
     """
 
-    user_agent: str = f"Mozilla/5.0 (compatible; rule34Py/{__version__})"
+    CAPTCHA_COOKIE_KEY: str = "cf_clearance"
+
+    user_agent: str = os.environ.get("R34_USER_AGENT", "Mozilla/5.0 (compatible; test)")
+    captcha_clearance: str | None = os.environ.get("R34_CAPTCHA_CLEARANCE", None)
 
     def __init__(self):
         """Initialize a new rule34 API client instance.
@@ -70,8 +73,15 @@ class rule34Py():
         :return: A requests.Response object from the GET request.
         :rtype: requests.Response
         """
-        kwargs["headers"] = kwargs.get("headers", {}) | \
-            {"User-Agent": self.user_agent}
+        # headers
+        kwargs.setdefault("headers", {})
+        kwargs["headers"].setdefault("User-Agent", self.user_agent)
+
+        # cookies
+        kwargs.setdefault("cookies", {})
+        if self.captcha_clearance is not None:
+            kwargs["cookies"]["cf_clearance"] = self.captcha_clearance
+
         return requests.get(*args, **kwargs)
 
     def get_comments(self, post_id: int) -> list:

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -41,9 +41,6 @@ from rule34Py.post import Post
 from rule34Py.post_comment import PostComment
 from rule34Py.toptag import TopTag
 
-"""
-TODO: fix typos
-"""
 
 SEARCH_RESULT_MAX = 1000  # API-defined maximum number of search results per request. <https://rule34.xxx/index.php?page=help&topic=dapi>
 

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -242,49 +242,30 @@ class rule34Py():
 
         return retURL
 
-    def random_post(self, tags: list = None):
-        """
-        Get a random post.
+    def random_post(self) -> Post:
+        """Get a random post.
 
-        :param tags: Tag list to search. If none, post will be used regardless
-                    of it tags.
-        :type tags: list[str]
+        This method behaves similarly to the website's Post > Random function.
 
         :return: Post object.
         :rtype: Post
         """
+        return self.get_post(self.random_post_id())
 
-        ## Fixed bug: https://github.com/b3yc0d3/rule34Py/issues/2#issuecomment-902728779
-        if tags != None:
+    def random_post_id(self) -> int:
+        """Get a random Post ID.
 
-            search_raw = self.search(tags, limit=1000)
-            if search_raw == []:
-                return []
+        This method returns the Post ID contained in the 302 redirect the
+        website responds with, when you request use random post function.
 
-            randnum = random.randint(0, len(search_raw)-1)
-
-            while len(search_raw) <= 0:
-                search_raw = self.search(tags)
-            else:
-                return search_raw[randnum]
-
-        else:
-            return self.get_post(self._random_post_id())
-
-    def _random_post_id(self) -> str:
-        """
-        Get a random posts id.
-
-        **This function is only used internally.**
-
-        :return: Random post id
-        :rtype: str
+        :return: A random Post ID.
+        :rtype: int
         """
 
-        res = requests.get(API_URLS.RANDOM_POST.value, headers=__headers__)
-        parsed = urlparse.urlparse(res.url)
-
-        return parse_qs(parsed.query)['id'][0]
+        response = self._get(API_URLS.RANDOM_POST.value)
+        response.raise_for_status()
+        parsed = urlparse.urlparse(response.url)
+        return int(parse_qs(parsed.query)['id'][0])
 
     def search(self,
         tags: list[str] = [],

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -31,7 +31,6 @@ import requests
 from rule34Py.__vars__ import (
     __api_url__,
     __base_url__,
-    __headers__,
     __version__,
 )
 from rule34Py.api_urls import API_URLS
@@ -42,6 +41,7 @@ from rule34Py.post_comment import PostComment
 from rule34Py.toptag import TopTag
 
 
+DEFAULT_USER_AGENT = f"Mozilla/5.0 (compatible; rule34Py/{__version__})"
 SEARCH_RESULT_MAX = 1000  # API-defined maximum number of search results per request. <https://rule34.xxx/index.php?page=help&topic=dapi>
 
 
@@ -60,7 +60,7 @@ class rule34Py():
     _base_site_rate_limiter = LimiterAdapter(per_second=1)
     captcha_clearance: str | None = os.environ.get("R34_CAPTCHA_CLEARANCE", None)
     session: requests.Session = None
-    user_agent: str = os.environ.get("R34_USER_AGENT", "Mozilla/5.0 (compatible; test)")
+    user_agent: str = os.environ.get("R34_USER_AGENT", DEFAULT_USER_AGENT)
 
     def __init__(self):
         """Initialize a new rule34 API client instance.

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -304,7 +304,7 @@ class rule34Py():
             params.append(["PAGE_ID", str(page_id)])
 
         formatted_url = self._parseUrlParams(url, params)
-        response = requests.get(formatted_url, headers=__headers__)
+        response = self._get(formatted_url)
         response.raise_for_status()
 
         # The Rule34 List API endpoint always returns code 200. But the response

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -147,34 +147,28 @@ class rule34Py():
 
         return ret_posts
 
-    def get_post(self, post_id: int) -> Post:
-        """
-        Get post by its id.
+    def get_post(self, post_id: int) -> Post | None:
+        """Get a Post by its ID.
 
-        :param post_id: Id of post.
+        :param post_id: The Post's ID number.
         :type post_id: int
 
-        :return: Post object.
-        :rtype: Post
+        :return: The Post object matching the post_id; or None, if the post_id is not found.
+        :rtype: Post | None
         """
-
         params = [
             ["POST_ID", str(post_id)]
         ]
         formatted_url = self._parseUrlParams(API_URLS.GET_POST.value, params)
-        response = requests.get(formatted_url, headers=__headers__)
+        response = self._get(formatted_url)
+        response.raise_for_status()
 
-        res_status = response.status_code
-        res_len = len(response.content)
-        ret_posts = []
+        # The Posts list API returns an empty response when filters match no posts.
+        if len(response.content) == 0:
+            return None
 
-        if res_status != 200 or res_len <= 0:
-            return ret_posts
-
-        for post in response.json():
-            ret_posts.append(Post.from_json(post))
-
-        return ret_posts if len(ret_posts) > 1 else (ret_posts[0] if len(ret_posts) == 1 else ret_posts)
+        post_json = response.json()
+        return Post.from_json(post_json[0])
 
     def icame(self) -> list:
         """Retrieve list of top 100 iCame list.

--- a/tests/README.md
+++ b/tests/README.md
@@ -33,4 +33,4 @@ export R34_RECORD_RESPONSES=True
 python3 -m pytest tests/
 ```
 
-Remember to commmit the registry file changes with your test changes.
+Remember to commit the registry file changes with your test changes.

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,12 +5,11 @@ This project is tested by an organic test suite based on `pytest`.
 
 ## Running the Test Suite
 
-To run the unit tests on your repo's source code, install the test suite dependencies declared in `:tests/requirements.txt` and invoke pytest.
+To run the unit tests on your repo's source code, install the test suite dependencies declared in `:pyproject.toml` and invoke pytest.
 
 ```bash
 # from the repository root directory ...
-source venv/bin/activate
-pip install -r tests/requirements.txt
+pip install .[test]
 
 python3 -m pytest tests/
 ```

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,0 @@
-pytest
-requests
-responses

--- a/tests/unit/test_html.py
+++ b/tests/unit/test_html.py
@@ -2,19 +2,30 @@
 import pytest
 
 from rule34Py.api_urls import API_URLS
-from rule34Py.html import TagMapPage, ICamePage, TopTagsPage
+from rule34Py.html import *
 from rule34Py.icame import ICame
 from rule34Py.toptag import TopTag
 
 
 ICAME_CHART_LEN = 100  # It's the top-100 chart.
+HISTORY_POOL_ID = 720  # Arbitrary old pool w/ lots of history, that hasn't been updated recently.
 TAGMAP_LOCATION_COUNT = 285  # There are 285 districts on the map
 TOP_TAGS_CHART_LEN = 100  # It's a top-100 chart.
 
 
+# FIXTURES #
+############
+
 @pytest.fixture(scope="module")
 def icame_html(rule34):
     resp = rule34._get(API_URLS.ICAME.value)
+    resp.raise_for_status()
+    return resp.text
+
+
+@pytest.fixture(scope="module")
+def pool_history_html(rule34):
+    resp = rule34._get(f"https://rule34.xxx/index.php?page=pool&s=history&id={HISTORY_POOL_ID}")
     resp.raise_for_status()
     return resp.text
 
@@ -25,12 +36,16 @@ def tagmap_html(rule34):
     resp.raise_for_status()
     return resp.text
 
+
 @pytest.fixture(scope="module")
 def toptags_html(rule34):
     resp = rule34._get(API_URLS.TOPMAP.value)
     resp.raise_for_status()
     return resp.text
 
+
+# TESTS #
+#########
 
 def test_ICamePage_init(icame_html):
     """The ICamePage class can be instantiated from html."""
@@ -44,6 +59,56 @@ def test_ICamePage_top_chart_from_html(icame_html):
     assert isinstance(top_chart, list)
     assert len(top_chart) == ICAME_CHART_LEN
     assert isinstance(top_chart[0], ICame)
+
+
+def test__PoolHistoryPage__events_from_html(rule34):
+    """The events_from_html() method parses history page html for its events."""
+    def get_pool_history_html(pool_id, pagination_index=0):
+        resp = rule34._get(f"https://rule34.xxx/index.php?page=pool&s=history&id={HISTORY_POOL_ID}&pid={pagination_index}")
+        print(resp.headers)
+        print(resp.text)
+        resp.raise_for_status()
+        return resp.text
+
+    # Pool #720 is arbitrarily chosen because it has a long history, but is not
+    # recently updated.
+    events = PoolHistoryPage.events_from_html(get_pool_history_html(720, 0))
+    assert isinstance(events, list)
+    assert len(events) == 50  # 50 is the max events per page
+    assert isinstance(events[0], PoolHistoryEvent)
+    # This event list should overlap with the last 49 entries in the prior.
+    events2 = PoolHistoryPage.events_from_html(get_pool_history_html(720, 1))
+    dates1 = set([e.date for e in events][1:])
+    dates2 = set([e.date for e in events2][:49])
+    assert dates1 == dates2
+
+
+def test__PoolPage__pool_from_html(rule34):
+    """The pool_from_html() method generates a Pool object from a page."""
+    def get_pool_html(pool_id):
+        resp = rule34._get(f"https://rule34.xxx/index.php?page=pool&s=show&id={pool_id}")
+        print(resp.headers)
+        print(resp.text)
+        resp.raise_for_status()
+        return resp.text
+    # pool 233 chosen because it is: unlikely to change, static in size, and has
+    # a differing name and description.
+    pool = PoolPage.pool_from_html(get_pool_html(233))
+    assert isinstance(pool, Pool)
+    assert pool.pool_id == 233
+    assert pool.name == "[Sparrow] Learning Her Lesson"
+    assert pool.description == "Sparrows work - depicting the milf Farah teaching a class about \"sexual arts\"\
+(http://g.e-hentai.org/g/267651/39325aedbe/)"
+    assert len(pool.posts) == 6
+    assert pool.posts[0] == 1506559
+    assert pool.posts[5] == 1506564
+
+    # Pool 920 is empty (0 posts) and has no description.
+    pool = PoolPage.pool_from_html(get_pool_html(920))
+    assert pool.pool_id == 920
+    assert pool.name == "[Adam Wan] November's Bribe"
+    assert pool.description == ""
+    assert len(pool.posts) == 0
 
 
 def test_TagMapPage_init(tagmap_html):

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -49,5 +49,6 @@ def test_search(rule34):
 def test_get_pool(rule34):
     """The client can get the example pool by id."""
     pool = rule34.get_pool(EXAMPLE_POOL)
-    assert isinstance(pool, list)
-    assert len(pool) > 0  # there should be posts here
+    assert isinstance(pool, rule34Py.Pool)
+    assert pool.pool_id == 28
+    assert len(pool.posts) > 0  # there should be posts here

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -51,9 +51,3 @@ def test_get_pool(rule34):
     pool = rule34.get_pool(EXAMPLE_POOL)
     assert isinstance(pool, list)
     assert len(pool) > 0  # there should be posts here
-
-def test_random_post(rule34):
-    """The client can get a random post tagged 'neko.'"""
-    # This will actually be the same post, as the request passes through the mock server.
-    post = rule34.random_post(["neko"])
-    assert isinstance(post, Post)  # just check that it is a post

--- a/tests/unit/test_rule34Py.py
+++ b/tests/unit/test_rule34Py.py
@@ -9,6 +9,7 @@ from rule34Py.rule34 import SEARCH_RESULT_MAX
 from rule34Py.post_comment import PostComment
 from rule34Py.icame import ICame
 from rule34Py.toptag import TopTag
+from rule34Py.__vars__ import __version__ as R34_VERSION
 
 
 TEST_POOL_ID = 28  # An arbitrary, very-old pool, that is probably stable.
@@ -78,6 +79,21 @@ def test_rule34Py_iter_search(rule34):
     # transparently move to the next page.
     results = list(rule34.iter_search(["female"], max_results=1002))
     assert len(results) == 1002
+
+
+def test__rule34Py__user_agent(rule34):
+    """The client has a user agent attribute that can be user-defined."""
+    # Default should be something like "Mozilla/... rule34Py/1.2.3"
+    print(rule34.user_agent)
+    assert "Mozilla" in rule34.user_agent
+    assert "rule34Py" in rule34.user_agent
+    assert R34_VERSION in rule34.user_agent
+    
+    # The user_agent can be changed.
+    rule34.user_agent = "foobar"
+    resp = rule34._get("http://example.com")
+    print(resp.request.headers)
+    assert resp.request.headers["User-Agent"] == "foobar"
 
 
 def test_rule34Py_get_post(rule34):

--- a/tests/unit/test_rule34Py.py
+++ b/tests/unit/test_rule34Py.py
@@ -90,10 +90,16 @@ def test_rule34Py_random_post(rule34):
     """The client random_post() method fetches a random Post object.
     """
     post = rule34.random_post()
+    print(post)
     assert isinstance(post, Post)
-    # You can specify tags to limit the random search
-    post = rule34.random_post(tags=["neko"])
-    assert "neko" in post.tags
+
+
+def test_rul34Py_random_post_id(rule34):
+    """The client random_post_id() method fetches a random Post ID number."""
+    id = rule34.random_post_id()
+    print(f"id={id}")
+    assert isinstance(id, int)
+    assert id > 0
 
 
 def test_rule34Py_search(rule34):

--- a/tests/unit/test_rule34Py.py
+++ b/tests/unit/test_rule34Py.py
@@ -97,7 +97,7 @@ def test_rule34Py_random_post(rule34):
     assert isinstance(post, Post)
 
 
-def test_rul34Py_random_post_id(rule34):
+def test_rule34Py_random_post_id(rule34):
     """The client random_post_id() method fetches a random Post ID number."""
     id = rule34.random_post_id()
     print(f"id={id}")

--- a/tests/unit/test_rule34Py.py
+++ b/tests/unit/test_rule34Py.py
@@ -4,7 +4,7 @@ import re
 
 import pytest
 
-from rule34Py import Post
+from rule34Py import Post, Pool
 from rule34Py.rule34 import SEARCH_RESULT_MAX
 from rule34Py.post_comment import PostComment
 from rule34Py.icame import ICame
@@ -27,20 +27,12 @@ def test_rule34Py_get_pool(rule34):
     TEST_POOL_ID = 28  # An arbitrary, very-old pool, that is probably stable.
     TEST_NUM_POSTS = 14  # there are 14 posts in this pool
     FIRST_POST_ID = 952001
-    post_ids = rule34.get_pool(pool_id=TEST_POOL_ID, fast=True)
-    # when Fast=True, return type is list[int]
-    assert isinstance(post_ids, list)
-    assert len(post_ids) == TEST_NUM_POSTS
-    assert isinstance(post_ids[0], int)
-    assert post_ids[0] == FIRST_POST_ID
 
-    # Test non-fast operation
-    posts = rule34.get_pool(pool_id=TEST_POOL_ID, fast=False)
-    # when Fast=False, return type is list[Post]
-    assert isinstance(posts, list)
-    assert len(posts) == TEST_NUM_POSTS
-    assert isinstance(posts[0], Post)
-    assert posts[0].id == FIRST_POST_ID
+    pool = rule34.get_pool(pool_id=TEST_POOL_ID)
+    assert isinstance(pool, Pool)
+    assert pool.pool_id == TEST_POOL_ID
+    assert len(pool.posts) == TEST_NUM_POSTS
+    assert pool.posts[0] == FIRST_POST_ID
 
 
 def test_rule34Py_get_post(rule34):

--- a/tests/unit/test_rule34Py.py
+++ b/tests/unit/test_rule34Py.py
@@ -86,6 +86,15 @@ def test_rule34Py_iter_search(rule34):
     assert len(results) == 1002
 
 
+def test_rule34Py_get_post(rule34):
+    """The client get_post() method fetches a single Post by post ID."""
+    post = rule34.get_post(8973658)
+    assert isinstance(post, Post)
+    assert post.id == 8973658
+    # Post #2 does not exist.
+    assert rule34.get_post(2) is None
+
+
 def test_rule34Py_random_post(rule34):
     """The client random_post() method fetches a random Post object.
     """
@@ -164,6 +173,7 @@ def test_rule34Py_top_tags(rule34):
     assert isinstance(top_tags, list)
     assert len(top_tags) == 100
     assert isinstance(top_tags[0], TopTag)
+
 
 def test_rule34Py_version(rule34):
     """The version() property should throw a deprecation warning, but return its original value.


### PR DESCRIPTION
This patchset is the second half of the changes I intend to make against the core client module (`:rule34Py/rule34.py`). It builds on what was submitted or release 2.1.0 in PR #20.


# Changes

* **[New Feature]** You can now specify a captcha clearance token from your browser via either the python API or from the runtime environment variables.
    * This token is basically required for client workflows that pull data from the interactive site, since rule34.xxx has returned to using captchas to gate bot access.
    * Note. I'm making a policy assertion with this change that it is reasonable and ethical to let this module continue accessing the interactive site, so long as the user pre-authenticates with a caption. I think this is reasonable because of the rate limiting feature I have also added.
* **[New Feature]** Rate limiter for the interactive site. The client now uses the [requests-ratelimiter](https://pypi.org/project/requests-ratelimiter/) module to rate-limit HTTP requests to the interactive site.
    * requests-ratelimiter is MIT licensed.
    * By default, the ratelimit is set at one access per second - which I think is fine for most usecases.
    * The rate limit does not apply to the api.rule34.xxx endpoints, since I assume those are rate-limited on the server-side.
* **[Breaking]** The client `random_post()` method now accesses the interactive site to request a random post ID from the 302 redirect that happens when you click the 'Random Post' button on the site. See the commit and changelog for how someone can recreate the older behavior using simple python logic.
* **[New Feature][Breaking]** The client `get_pool()` method now does more than just return a list of post IDs in a pool. It now actually parses the pool-specific metadata (name, description, et c.) from the pool object on the site, and returns a rich object with that information.
    * It also parses the pool's change history and returns that as a sequence of historical events.
    * Users who want the old behavior can just access the new `Pool.posts` attribute. This is explained in the changelog.
* Fixed a typo in the project description ("wraper" -> "wrapper"). Not a functional change, but user-facing.

Other minor changes aren't mentioned here, but are explained in the commit messages.

This patchset updates the changelog.


# Testing

* [x] Unit tests have been updated and extended to cover the new methods I have touched here.

```bash
$ python -m pytest -v ./tests/unit/
===================================================================== test session starts =====================================================================
platform linux -- Python 3.13.2, pytest-8.3.5, pluggy-1.5.0 -- rule34Py/.venv/bin/python
cachedir: .pytest_cache
rootdir: rule34Py/tests
configfile: pytest.ini
collected 29 items                                                                                                                                            

tests/unit/test_html.py::test_ICamePage_init PASSED                                                                                                     [  3%]
tests/unit/test_html.py::test_ICamePage_top_chart_from_html PASSED                                                                                      [  6%]
tests/unit/test_html.py::test__PoolHistoryPage__events_from_html PASSED                                                                                 [ 10%]
tests/unit/test_html.py::test__PoolPage__pool_from_html PASSED                                                                                          [ 13%]
tests/unit/test_html.py::test_TagMapPage_init PASSED                                                                                                    [ 17%]
tests/unit/test_html.py::test_TagMapPage_map_points_from_html PASSED                                                                                    [ 20%]
tests/unit/test_html.py::test_TopTagsPage PASSED                                                                                                        [ 24%]
tests/unit/test_html.py::test_TopTagsPage_top_tags_from_html PASSED                                                                                     [ 27%]
tests/unit/test_module.py::test_version PASSED                                                                                                          [ 31%]
tests/unit/test_readme.py::test_module_import PASSED                                                                                                    [ 34%]
tests/unit/test_readme.py::test_get_comments PASSED                                                                                                     [ 37%]
tests/unit/test_readme.py::test_get_post PASSED                                                                                                         [ 41%]
tests/unit/test_readme.py::test_icame PASSED                                                                                                            [ 44%]
tests/unit/test_readme.py::test_search PASSED                                                                                                           [ 48%]
tests/unit/test_readme.py::test_get_pool PASSED                                                                                                         [ 51%]
tests/unit/test_rule34Py.py::test_rule34Py_get_comments PASSED                                                                                          [ 55%]
tests/unit/test_rule34Py.py::test_rule34Py_get_pool PASSED                                                                                              [ 58%]
tests/unit/test_rule34Py.py::test_rule34Py_get_post PASSED                                                                                              [ 62%]
tests/unit/test_rule34Py.py::test_rule34Py_icame PASSED                                                                                                 [ 65%]
tests/unit/test_rule34Py.py::test_rule34Py_iter_search PASSED                                                                                           [ 68%]
tests/unit/test_rule34Py.py::test__rule34Py__user_agent PASSED                                                                                          [ 72%]
tests/unit/test_rule34Py.py::test_rule34Py_random_post PASSED                                                                                           [ 75%]
tests/unit/test_rule34Py.py::test_rule34Py_random_post_id PASSED                                                                                        [ 79%]
tests/unit/test_rule34Py.py::test__rule34Py__request_limiter PASSED                                                                                     [ 82%]
tests/unit/test_rule34Py.py::test_rule34Py_search PASSED                                                                                                [ 86%]
tests/unit/test_rule34Py.py::test_rule34Py_tag_map PASSED                                                                                               [ 89%]
tests/unit/test_rule34Py.py::test_rule34Py_tagmap PASSED                                                                                                [ 93%]
tests/unit/test_rule34Py.py::test_rule34Py_top_tags PASSED                                                                                              [ 96%]
tests/unit/test_rule34Py.py::test_rule34Py_version PASSED                                                                                               [100%]

===================================================================== 29 passed in 25.47s =====================================================================
```

# Notes

1. I'm intentionally now using double__underlines in the new test names as a delimiter. I think this is a better style that I have seen in other projects. I'll post a future patchset that homogenizes the naming.
2. I realize I've been breaking a lot of the API and only doing light method documentation. My next major effort will be to improve the project's documentation (probably sphinx-docs) and proper documentation for the client module will be the first thing I add.


# Procedure
* I release all copyright ownership to b3yc0d3.