### PR TITLE
feat: add tag autocomplete functionality

### DIFF
--- a/rule34Py/api_urls.py
+++ b/rule34Py/api_urls.py
@@ -23,7 +23,7 @@ from enum import Enum
 
 __base_url__ = "https://rule34.xxx/"
 __api_url__ = "https://api.rule34.xxx/"
-
+__autocomplete_url__ = "https://ac.rule34.xxx/"
 
 class API_URLS(str, Enum):
     """rule34.xxx API endpoint URLs.
@@ -48,3 +48,5 @@ class API_URLS(str, Enum):
     POOL = f"{__base_url__}index.php?page=pool&s=show&id={{POOL_ID}}"
     #: The HTML toptags URL.
     TOPMAP = f"{__base_url__}index.php?page=toptags"
+    #: The tags autocomplete URL
+    AUTOCOMPLETE = f"{__autocomplete_url__}autocomplete.php?q={{q}}"

--- a/rule34Py/autocomplete_tag.py
+++ b/rule34Py/autocomplete_tag.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+
+@dataclass
+class AutocompleteTag:
+    """Represents a tag suggestion from autocomplete.
+
+    Parameters:
+        label: The full tag label including count (e.g., "hooves (95430)").
+        value: The clean tag value (e.g., "hooves").
+        type: The tag category (e.g., "general", "copyright").
+    """
+
+    #: The full tag label including count (e.g., "hooves (95430)").
+    label: str
+    #: The clean tag value without count information.
+    value: str
+    #: The category of the tag (general/copyright/other).
+    type: str

--- a/rule34Py/autocomplete_tag.py
+++ b/rule34Py/autocomplete_tag.py
@@ -1,3 +1,21 @@
+# rule34Py - Python api wrapper for rule34.xxx
+# 
+# Copyright (C) 2022-2025 b3yc0d3 <b3yc0d3@gmail.com>
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Provides the AutocompleteTag class used for tag suggestions from Rule34 autocomplete."""
+
 from dataclasses import dataclass
 
 @dataclass

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -85,11 +85,14 @@ class rule34Py():
 
     def autocomplete(self, tag_string: str) -> list[AutocompleteTag]:
         """Retrieve tag suggestions based on partial input.
+
         Args:
             tag_string: Partial tag input to search suggestions for.
+
         Returns:
             A list of AutocompleteTag objects matching the search query,
             ordered by popularity (descending).
+
         Raises:
             requests.HTTPError: The backing HTTP request failed.
             ValueError: If the response contains invalid data structure.

--- a/tests/unit/test_rule34Py.py
+++ b/tests/unit/test_rule34Py.py
@@ -10,11 +10,29 @@ from rule34Py.rule34 import SEARCH_RESULT_MAX
 from rule34Py.post_comment import PostComment
 from rule34Py.icame import ICame
 from rule34Py.toptag import TopTag
-
+from rule34Py.autocomplete_tag import AutocompleteTag
 
 TEST_POOL_ID = 28  # An arbitrary, very-old pool, that is probably stable.
 R34_VERSION = importlib.metadata.version("rule34Py")
 
+def test_rule34Py_autocomplete(rule34):
+    """The autocomplete method should return a list of tag suggestions."""
+    suggestions = rule34.autocomplete("neko")
+    
+    assert isinstance(suggestions, list)
+    
+    if suggestions:
+        first = suggestions[0]
+        assert isinstance(first, AutocompleteTag)
+        assert hasattr(first, 'label')
+        assert hasattr(first, 'value')
+        assert hasattr(first, 'type')
+        assert isinstance(first.label, str)
+        assert isinstance(first.value, str)
+        assert isinstance(first.type, str)
+
+    empty_suggestions = rule34.autocomplete("")
+    assert isinstance(empty_suggestions, list)
 
 def test_rule34Py_get_comments(rule34):
     """The get_comments() method should fetch a list of comments from a post.


### PR DESCRIPTION
Add new autocomplete() method to rule34Py class that provides tag suggestions
based on partial input. Includes new AutocompleteTag class to represent
suggestion results and required API URL configuration.

Changes include:
- New autocomplete() method in rule34.py with full type hints and docs
- AutocompleteTag class in autocomplete_tag.py with property accessors
- Added AUTOCOMPLETE URL constant in __vars__.py
- Updated API_URLS with new URL for autocomplete

Method returns suggestions ordered by popularity. Includes referer/origin
headers for compatibility.