### PR TITLE
Exclude ai generated content from search resulsts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [unreleased] - 2025-08-24
+## [unreleased] - 2025-08-30
 
 ### Added
- - Added a `rule34.autocomplete` method.
+ - Added a `rule34Py.autocomplete` method.
  - Added `AutocompleteTag` class.
+ - Added parameter to `rule34Py.search` method for excluding ai generated content.
+ 	- Added unit test
 
 ### Changed
  - Updated API wrapper to support website’s new authentication system.
  - The underlying website API now **requires authentication** (`api_key` and `user_id`) for all requests.
- - Updated unit tests
+ - Updated unit tests.
 
 ## [3.0.0] - 2025-06-09
 

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -25,7 +25,6 @@ import importlib.metadata
 import os
 import urllib.parse as urlparse
 import warnings
-import json
 
 from bs4 import BeautifulSoup
 from requests_ratelimiter import LimiterAdapter

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -25,6 +25,7 @@ import importlib.metadata
 import os
 import urllib.parse as urlparse
 import warnings
+import json
 
 from bs4 import BeautifulSoup
 from requests_ratelimiter import LimiterAdapter
@@ -146,7 +147,9 @@ class rule34Py:
 
         # check if api credentials are set
         if is_api_request and self.user_id == None and self.api_key == None:
-            raise ValueError("API credentials must be supplied, api_key and user_id can not be None!\nSee https://api.rule34.xxx/ for more information.")
+            raise ValueError(
+                "API credentials must be supplied, api_key and user_id can not be None!\nSee https://api.rule34.xxx/ for more information."
+            )
 
         # headers
         kwargs.setdefault("headers", {})
@@ -361,6 +364,7 @@ class rule34Py:
     def search(
         self,
         tags: list[str] = [],
+        exclude_ai: bool = False,
         page_id: Union[int, None] = None,
         limit: int = SEARCH_RESULT_MAX,
     ) -> list[Post]:
@@ -368,6 +372,8 @@ class rule34Py:
 
         Args:
             tags: A list of tags to search for.
+            exclude_id: Exclude ai generated content from the results.
+                Default is False.
             page_id: The search page number to request, or None.
                 If None, search will eventually return all pages.
             limit: The maximum number of post results to return per page.
@@ -385,6 +391,12 @@ class rule34Py:
         """  # noqa: DOC502
         if limit < 0 or limit > SEARCH_RESULT_MAX:
             raise ValueError(f"Search limit must be between 0 and {SEARCH_RESULT_MAX}.")
+
+        # exclude all tags starting with ai if user whishes so
+        if exclude_ai == True:
+            # filter out any ai tag
+            tags = [tag for tag in tags if not tag.lower().startswith("ai")]
+            tags.append("-ai*")
 
         params = [
             ["TAGS", "+".join(tags)],

--- a/tests/unit/test_rule34Py.py
+++ b/tests/unit/test_rule34Py.py
@@ -207,6 +207,17 @@ def test_rule34Py_search(rule34):
     with pytest.raises(ValueError):
         rule34.search([], limit=SEARCH_RESULT_MAX + 1)
 
+def test_rule34Py_search_exclude_ai(rule34):
+    """The client can search for posts by tags, with excluding ai generated content."""
+    # search by single tag
+    results1 = rule34.search(["neko"], exclude_ai=True)
+    ids1 = [post.id for post in results1]
+    print(f"ids1={ids1[:10]}...")
+    assert isinstance(results1, list)  # return type is list
+    
+    assert len(results1) == SEARCH_RESULT_MAX
+    assert isinstance(results1[0], Post)  # return list contains Post objects
+
 
 def test_rule34Py_tag_map(rule34):
     """The client tag_map() method should return a map of tags.


### PR DESCRIPTION
Added parameter to search function for excluding ai generated content from their search results,
by setting ``exclude_ai`` to True.

**Example**:
```py
import rule34Py as r34

client = r34.rule34Py()

client.api_key="API_KEY"
client.user_id="USER_ID"

results = client.search(["neko"], exclude_ai=True)
```