### PR TITLE
Changed autocomplete API endpoint url Closes #39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased] - 2025-08-31
+
+### Changed
+ - Switched from front-end API url to *official* REST API url for autocompletion.
+ - Updated documentation for `rule34Py.autocomplete`
+ - Updated unit tests
+ - Changed `API_URLS.AUTOCOMPLETE` to semi official endpoint
 
 ## [4.0.0] - 2025-08-31
 

--- a/docs/api/rule34Py/__init__.rst
+++ b/docs/api/rule34Py/__init__.rst
@@ -20,3 +20,4 @@ rule34Py
    post_comment
    rule34
    toptag
+   autocomplete_tag

--- a/docs/api/rule34Py/autocomplete_tag.rst
+++ b/docs/api/rule34Py/autocomplete_tag.rst
@@ -1,0 +1,5 @@
+rule34Py.autocomplete_tag
+=========================
+
+.. automodule:: rule34Py.autocomplete_tag
+   :members:

--- a/rule34Py/api_urls.py
+++ b/rule34Py/api_urls.py
@@ -23,7 +23,6 @@ from enum import Enum
 
 __base_url__ = "https://rule34.xxx/"
 __api_url__ = "https://api.rule34.xxx/"
-__autocomplete_url__ = "https://ac.rule34.xxx/"
 
 class API_URLS(str, Enum):
     """rule34.xxx API endpoint URLs.
@@ -49,4 +48,4 @@ class API_URLS(str, Enum):
     #: The HTML toptags URL.
     TOPMAP = f"{__base_url__}index.php?page=toptags"
     #: The tags autocomplete URL
-    AUTOCOMPLETE = f"{__autocomplete_url__}autocomplete.php?q={{q}}"
+    AUTOCOMPLETE = f"{__api_url__}autocomplete.php?q={{q}}"

--- a/rule34Py/autocomplete_tag.py
+++ b/rule34Py/autocomplete_tag.py
@@ -22,6 +22,10 @@ from dataclasses import dataclass
 class AutocompleteTag:
     """Represents a tag suggestion from autocomplete.
 
+        .. important::
+            
+            Do to switching from the website endpoint to the REST API endpoint, the``type`` is currently always **None**.
+
     Parameters:
         label: The full tag label including count (e.g., "hooves (95430)").
         value: The clean tag value (e.g., "hooves").
@@ -33,4 +37,8 @@ class AutocompleteTag:
     #: The clean tag value without count information.
     value: str
     #: The category of the tag (general/copyright/other).
-    type: str
+    #:
+    #: .. important::
+    #:
+    #:     Do to switching from the website endpoint to the REST API endpoint, the``type`` is currently always **None**.
+    type: str | None

--- a/rule34Py/rule34.py
+++ b/rule34Py/rule34.py
@@ -114,19 +114,12 @@ class rule34Py:
         """  # noqa: DOC502
         params = [["q", tag_string]]
         formatted_url = self._parseUrlParams(API_URLS.AUTOCOMPLETE.value, params)
-        response = self._get(
-            formatted_url,
-            headers={
-                "Referer": "https://rule34.xxx/",
-                "Origin": "https://rule34.xxx",
-                "Accept": "*/*",
-            },
-        )
+        response = self._get(formatted_url)
         response.raise_for_status()
 
         raw_data = response.json()
         results = [
-            AutocompleteTag(label=item["label"], value=item["value"], type=item["type"])
+            AutocompleteTag(label=item["label"], value=item["value"], type=None)
             for item in raw_data
         ]
         return results

--- a/tests/unit/test_rule34Py.py
+++ b/tests/unit/test_rule34Py.py
@@ -29,7 +29,7 @@ def test_rule34Py_autocomplete(rule34):
         assert hasattr(first, 'type')
         assert isinstance(first.label, str)
         assert isinstance(first.value, str)
-        assert isinstance(first.type, str)
+        assert isinstance(first.type, str | None)
 
     empty_suggestions = rule34.autocomplete("")
     assert isinstance(empty_suggestions, list)


### PR DESCRIPTION
See Issue #39 for more information

### Changed
 - Switched from front-end API url to *official* REST API url for autocompletion.
 - Updated documentation for `rule34Py.autocomplete`
 - Updated unit tests
 - Changed `API_URLS.AUTOCOMPLETE` to semi official endpoint